### PR TITLE
create ability for bootcamper to apply for jobs

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -17,8 +17,9 @@ import { BrowserRouter as Router, Route, Switch, Link } from "react-router-dom";
 
 import "./App.css";
 
-// const userType = 'bootcamper'
-const userType = 'company'
+const userType = 'bootcamper'
+// const userType = 'company'
+
 function App() {
   return (
     <Router>

--- a/client/src/Components/BootcampApplications/BootcampApplications.jsx
+++ b/client/src/Components/BootcampApplications/BootcampApplications.jsx
@@ -1,12 +1,58 @@
-import React, { Component} from 'react';
+import React, { useState, Fragment} from 'react';
+import axios from "axios";
 
-class BootcampApplications extends Component {
+const BootcampApplications = () => {
+  const [state, setState] = useState({
+    date_applied: new Date(),
+    rejected: false,
+    accepted: false,
+    applicationSubmitted: false
+  });
 
-  render() { 
-    return ( 
-      <h1>This is the BootcampAPPLICATIONS component</h1>
-    );
-  }
-}
- 
+  const handleChange = e => {
+    const { name, value } = e.target;
+    setState({ ...state, [name]: Number(value) });
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    const endpoint = "http://localhost:3000/job-applications/add-application";
+
+    const payload = {
+      date_applied: state.date_applied,
+      rejected: state.rejected,
+      accepted: state.accepted,
+      users_id: 1, /* we need to pull this from session or something similar */
+      posts_jobs_id: state.posts_jobs_id
+    };
+
+    const response = await axios.post(endpoint, payload);
+    setState({ ...state, applicationSubmitted: true });
+  };
+
+  return (
+    <Fragment>
+      <h1>Submit an Application</h1>
+      {state.applicationSubmitted ? (
+        <div>
+          <h2>Thank you for submitting an application! We'll be in touch shortly.</h2>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit}>
+          <label>
+            Job to which you are applying:
+            <input
+              type="number"
+              name="posts_jobs_id"
+              value={state.name}
+              onChange={handleChange}
+            ></input>
+          </label>
+          <button type="submit">Submit Application</button>
+        </form>
+      )}
+    </Fragment>
+  );
+};
+
 export default BootcampApplications;


### PR DESCRIPTION
- Enables bootcamper to apply for a job but currently only by job id
- Need to pull user id from session or something similar (currently being specified manually)
- Need to think about what all data we need to `get` even in the process of `post`ing (e.g., referencing info about `users_id` as well as `posts_jobs_id` and the linked company and so forth)