### PR TITLE
Demo branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/server/restore-db.sh

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "private": true,
     "scripts": {
-        "db:reset": "dropdb codetrain; bash restore-db.sh",
+        "db:reset": "bash restore-db.sh",
         "start": "node ./bin/www",
         "dev": "nodemon --ignore 'sessions/' ./bin/www"
     },

--- a/server/restore-db.sh
+++ b/server/restore-db.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-createdb codetrain
-psql -f SQL/schema.sql codetrain
-psql -f SQL/seed.sql codetrain


### PR DESCRIPTION
**TL;DR** Follow the process outlined below to restore the database while also viewing it in Postico.

First changed the `db:reset` script in the `package.json` file in `server` to only be `bash restore-db.sh`. Then removed this script file from the Git repo and added to local `.gitignore` due to people using different operating systems. 

Here is the newly modified `restore-db.sh` script I am using that you may want to use as well (not sure what some of the equivalent commands might be, Prescott):

```BASH
pkill Postico
dropdb codetrain
createdb codetrain
psql -f SQL/schema.sql codetrain
psql -f SQL/seed.sql codetrain
cd /Applications/
open Postico.app
```

- This will kill the Postico process before any restoration attempt (so you don't have to worry about the weird errors we were getting earlier). Cool fact: you can still be using Postico when you execute `npm run db:reset` from within `server`, your Postico process will be killed and the database restored and then your view from Postico will also be restored.
- The `codetrain` database is then dropped (instead of doing this before running the restore script as was being done previously with `dropdb codetrain; bash restore-db.sh` in the `package.json`).
- The `codetrain` database is then recreated with our schema and seed data.
- Finally, assuming you are using Postico as your Postgres GUI (could be PGAdmin or whatever), you can then launch the application to reduce closing and opening of that application. Your prior view will be restored.

Small but decent improvement over what we had initially. 